### PR TITLE
Avoid attempting to parse empty response bodies for times.

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -139,6 +139,8 @@ module PagerDuty
       end
 
       def parse(body)
+        return body if body.respond_to?(:empty?) && body.empty?
+
         case body
         when Hash, ::Hashie::Mash
           OBJECT_KEYS.each do |key|


### PR DESCRIPTION
PagerDuty returns 204 with an empty body to DELETE requests for example.
