### PR TITLE
feat: accept a pre-built Faraday connection

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -199,7 +199,40 @@ module PagerDuty
       end
     end
 
-    def initialize(token, token_type: :Token, url: API_PREFIX, debug: false)
+    # api_middleware returns a proc that adds the request/response
+    # transformation middleware this class requires (time conversion, JSON
+    # encoding/decoding, API version header, mashifying) to a Faraday
+    # connection. It is applied during initialize, and is exposed for callers
+    # that build their own connection (see the connection: keyword) so they
+    # can compose it into their stack. Authentication, error raising, and the
+    # adapter are deliberately excluded — an injected connection brings its
+    # own.
+    def self.api_middleware
+      lambda do |conn|
+        conn.use ConvertTimesParametersToISO8601
+
+        # use json
+        conn.request :json
+        conn.headers[:accept] = "application/vnd.pagerduty+json;version=#{API_VERSION}"
+
+        # json back, mashify it
+        conn.use ParseTimeStrings
+        conn.use Mashify
+        conn.response :json
+      end
+    end
+
+    # Pass connection: to use a pre-built Faraday connection instead of having
+    # this class build one. The caller owns the full middleware stack,
+    # including authentication and error handling; apply self.api_middleware
+    # to it for the request/response transformations the request methods
+    # expect. token/token_type/url/debug are ignored when connection is given.
+    def initialize(token = nil, token_type: :Token, url: API_PREFIX, debug: false, connection: nil)
+      if connection
+        @connection = connection
+        return
+      end
+
       @connection = Faraday.new do |conn|
         conn.url_prefix = url
 
@@ -217,16 +250,7 @@ module PagerDuty
         else raise ArgumentError, "invalid token_type: #{token_type.inspect}"
         end
 
-        conn.use ConvertTimesParametersToISO8601
-
-        # use json
-        conn.request :json
-        conn.headers[:accept] = "application/vnd.pagerduty+json;version=#{API_VERSION}"
-
-        # json back, mashify it
-        conn.use ParseTimeStrings
-        conn.use Mashify
-        conn.response :json
+        self.class.api_middleware.call(conn)
         conn.response :logger, ::Logger.new($stdout), bodies: true if debug
 
         # Because Faraday::Middleware executes in reverse order of


### PR DESCRIPTION
Connection.new(connection:) uses a caller-supplied Faraday connection instead of building one from token/token_type. The request/response transformation middleware (time conversion, JSON, API version header, mashify) is extracted to Connection.api_middleware so callers building their own connection can compose it into their stack; authentication, error raising, and the adapter stay with whoever builds the connection.

Needed by On-Call Optimizer so PagerDuty requests run through its standard outbound transport stack (circuit breaking, logging, timeouts) — see the connection-failure-detection feature (US-003). Replaces the token_type: :Custom callback mechanism for that use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)